### PR TITLE
Debug session creation and time input issues

### DIFF
--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -9,7 +9,7 @@ export default function CreatePage() {
   const router = useRouter();
   const [title, setTitle] = useState('Sprint Kudos');
   const [anonymity, setAnonymity] = useState(true);
-  const [roundSeconds, setRoundSeconds] = useState(90);
+  const [roundSecondsStr, setRoundSecondsStr] = useState('90');
   const [language, setLanguage] = useState<'en' | 'pl'>('en');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -19,6 +19,8 @@ export default function CreatePage() {
     setError(null);
     setLoading(true);
     try {
+      const parsedRoundSeconds = parseInt(roundSecondsStr, 10);
+      const roundSeconds = Number.isFinite(parsedRoundSeconds) ? Math.min(600, Math.max(30, parsedRoundSeconds)) : 90;
       const res = await fetch('/api/session', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -45,7 +47,14 @@ export default function CreatePage() {
           Anonymity
         </label>
         <label className="block text-sm font-medium">Round seconds
-          <Input type="number" min={30} max={600} className="mt-1" value={roundSeconds} onChange={(e) => setRoundSeconds(parseInt(e.target.value || '0'))} />
+          <Input
+            type="number"
+            min={30}
+            max={600}
+            className="mt-1"
+            value={roundSecondsStr}
+            onChange={(e) => setRoundSecondsStr(e.target.value)}
+          />
         </label>
         <label className="block text-sm font-medium">Language
           <select className="mt-1 w-full border rounded px-3 py-2" value={language} onChange={(e) => setLanguage(e.target.value as 'en' | 'pl')}>

--- a/src/lib/mongo.ts
+++ b/src/lib/mongo.ts
@@ -22,7 +22,7 @@ export async function getCollection<T extends Document>(): Promise<Collection<T>
 export async function mongoUpsert<T extends Document & { id: string; sessionCode: string }>(doc: T & { expireAt?: Date }): Promise<void> {
   const col = await getCollection<T & { _id: string }>();
   const withId = { ...doc, _id: doc.id } as any;
-  await col.replaceOne({ _id: doc.id } as any, withId, { upsert: true });
+  await col.replaceOne({ _id: doc.id, sessionCode: doc.sessionCode } as any, withId, { upsert: true });
 }
 
 export async function mongoFindOne<T extends Document>(filter: Filter<T>, options?: { sort?: Sort }): Promise<T | null> {


### PR DESCRIPTION
## What
This PR addresses two issues:
1.  Fixes session creation failures when using Azure Cosmos DB for MongoDB.
2.  Enables free editing of the "Round seconds" input field on the session creation page.

## Why
1.  **Cosmos DB Session Creation Failure:** Azure Cosmos DB for MongoDB sharded collections require the shard key (`sessionCode`) to be included in the `replaceOne` filter for upsert operations. The previous implementation only used `_id`, leading to "Failed to create" errors.
2.  **Round Seconds Input Issue:** The "Round seconds" input field was bound to a numeric state, which prevented users from clearing the '0' value, making it difficult to enter custom times.

## How to test
1.  Ensure your Azure Cosmos DB for MongoDB collection's partition key is set to `sessionCode`.
2.  Deploy the application.
3.  Navigate to the `/create` page.
4.  **Test session creation:** Fill in the required details and click "Create Session". Verify that a session is successfully created without errors.
5.  **Test round seconds input:**
    *   Click on the "Round seconds" input field.
    *   Attempt to delete the default value (e.g., '90'). Verify that you can clear the field.
    *   Enter a new value (e.g., '45').
    *   Create a session with this new value and confirm it is applied.

## Checklist
- [ ] Tests added/updated
- [ ] Docs updated
- [ ] No secrets committed

---
<a href="https://cursor.com/background-agent?bcId=bc-f265628d-3452-4f13-a5af-29b9d88b7038">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f265628d-3452-4f13-a5af-29b9d88b7038">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

