### PR TITLE
Fix user kuds and session real-time

### DIFF
--- a/src/app/s/[code]/page.tsx
+++ b/src/app/s/[code]/page.tsx
@@ -78,9 +78,11 @@ export default function LobbyPage() {
         <p className="text-yellow-700">You have not joined. Go to Join page.</p>
       )}
       <ul className="grid grid-cols-2 gap-2">
-        {data?.participants.map((p) => (
-          <li key={p.id} className="border rounded px-3 py-2">{p.name}</li>
-        ))}
+        {data?.participants
+          .filter((p) => p.id !== participant?.id)
+          .map((p) => (
+            <li key={p.id} className="border rounded px-3 py-2">{p.name}</li>
+          ))}
       </ul>
     </main>
   );

--- a/src/app/s/[code]/round/[i]/page.tsx
+++ b/src/app/s/[code]/round/[i]/page.tsx
@@ -71,7 +71,7 @@ export default function RoundPage() {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ sessionCode: code, authorId: participant?.id, text }),
     });
-    if (res.ok) setSubmitted(true);
+    if (res.ok || res.status === 409) setSubmitted(true);
   }
 
   return (

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -27,6 +27,7 @@ export type ParticipantDoc = {
   sessionCode: string;
   name: string;
   email?: string;
+  isHost?: boolean;
   createdAt: string;
   _ttl?: number;
 };

--- a/src/lib/zod-schemas.ts
+++ b/src/lib/zod-schemas.ts
@@ -8,6 +8,7 @@ export const createSessionSchema = z.object({
     language: z.enum(['en', 'pl']).default('en'),
     roundCount: z.number().int().min(1).max(20).default(1),
   }),
+  hostName: z.string().min(1).max(50),
 });
 
 export const joinSchema = z.object({


### PR DESCRIPTION
## What
*   Implemented a backend restriction to allow only one KUDS submission per author per round, with the UI handling duplicate attempts gracefully.
*   Modified the lobby participant list to filter out the current user, preventing self-selection for KUDS.
*   Updated the session creation flow to require the creator's name, automatically designating them as the host and saving their participant ID locally.

## Why
*   To enforce the rule that each user can give KUDS to another user just once per round.
*   To prevent users from giving KUDS to themselves by not displaying their own card in the participant list.
*   To automatically assign the session creator as the host and capture their name during session setup.
*   (Real-time refresh for joins and session start was already covered by existing functionality.)

## How to test
1.  **One KUDS per user:**
    *   Create a session and join.
    *   Start a round and submit a KUDS to another user.
    *   Attempt to submit another KUDS to the *same* user; the UI should indicate it's already submitted without creating a new note.
2.  **Hide self:**
    *   Create a session. Verify your name does not appear in the participant list in the lobby.
    *   Join an existing session. Verify your name does not appear in the participant list in the lobby.
3.  **Host creation:**
    *   Navigate to the Create Session page.
    *   Observe the new "Your name (host)" input field.
    *   Create a session, providing your name. The session should be created successfully, and you will be the host.

## Checklist
- [ ] Tests added/updated
- [ ] Docs updated
- [ ] No secrets committed

---
<a href="https://cursor.com/background-agent?bcId=bc-b6435963-18b5-4edd-b3f9-20f7b2c1db22">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b6435963-18b5-4edd-b3f9-20f7b2c1db22">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

